### PR TITLE
chore(eslint-config): disallow .only to be used in tests

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: ['simple-import-sort', 'check-file', 'unused-imports'],
+  plugins: ['simple-import-sort', 'check-file', 'unused-imports', 'no-only-tests'],
   extends: ['airbnb-base', 'airbnb-typescript/base', 'prettier', 'plugin:anti-trojan-source/recommended'],
   ignorePatterns: ['dist'],
   rules: {
@@ -70,6 +70,11 @@ module.exports = {
           'Do not use ambiguous identifiers like `id`, use context identifiers like `userId` or `postId` instead.',
       },
     ],
+
+    /**
+     * disallow .only to be used in tests
+     */
+    'no-only-tests/no-only-tests': 'error',
   },
   env: {
     node: true,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -18,6 +18,7 @@
     "eslint-plugin-anti-trojan-source": "^1.1.1",
     "eslint-plugin-check-file": "^2.4.0",
     "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-unused-imports": "^2.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.59.11)(eslint@8.43.0)
+      eslint-plugin-no-only-tests:
+        specifier: ^3.1.0
+        version: 3.1.0
       eslint-plugin-simple-import-sort:
         specifier: ^10.0.0
         version: 10.0.0(eslint@8.43.0)
@@ -2401,6 +2404,11 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: false
+
+  /eslint-plugin-no-only-tests@3.1.0:
+    resolution: {integrity: sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==}
+    engines: {node: '>=5.0.0'}
     dev: false
 
   /eslint-plugin-simple-import-sort@10.0.0(eslint@8.43.0):


### PR DESCRIPTION
#### What this PR does / why we need it:

As per title.