### PR TITLE
feat(turbo): add `sticky-turbo plan` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,25 +27,6 @@ jobs:
 
       - run: pnpm build
 
-  Test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-
-      - run: corepack enable pnpm
-
-      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm test -- -- --maxWorkers=100% --coverage
-
-      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
-        with:
-          fail_ci_if_error: true
-
   lint_prettier:
     name: Lint (prettier)
     runs-on: ubuntu-latest
@@ -103,7 +84,7 @@ jobs:
       - id: plan
         run: |
           echo 'packages<<EOF' >> $GITHUB_OUTPUT
-          pnpm sticky-turbo plan ${{ inputs.script }} >> $GITHUB_OUTPUT
+          pnpm sticky-turbo plan test >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
   test_run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - run: pnpm build
 
   lint_prettier:
-    name: Lint (prettier)
+    name: Lint [prettier]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -45,7 +45,7 @@ jobs:
       - run: pnpm prettier --check .
 
   lint_eslint:
-    name: Lint (eslint)
+    name: Lint [eslint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,64 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm turbo run lint
+
+  test_plan:
+    name: Test [plan]
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.plan.outputs.packages }}
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - run: corepack enable pnpm
+
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # this step is only required in this repo because the cli source is not yet built
+      - run: pnpm turbo run build --filter=@stickyjs/turbo
+
+      - id: plan
+        run: |
+          echo 'packages<<EOF' >> $GITHUB_OUTPUT
+          pnpm sticky-turbo plan ${{ inputs.script }} >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+  test_run:
+    name: Test [run]
+    runs-on: ubuntu-latest
+    needs: test_plan
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.test_plan.outputs.packages) }}
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - run: corepack enable pnpm
+
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm turbo run test --concurrency=1 --filter=${{ matrix.package }} -- --coverage --forceExit
+
+      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+
+  test_completed:
+    name: Test [completed]
+    runs-on: ubuntu-latest
+    needs: test_run
+    if: always()
+    steps:
+      - run: |
+          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled') }} ; then
+            exit 1
+          fi

--- a/.github/workflows/oss-governance-bot.yml
+++ b/.github/workflows/oss-governance-bot.yml
@@ -1,4 +1,4 @@
-name: OSS Governance
+name: OSS
 
 on:
   pull_request_target:
@@ -16,7 +16,8 @@ permissions:
   checks: write
 
 jobs:
-  Bot:
+  main:
+    name: Governance Bot
     runs-on: ubuntu-latest
     steps:
       - uses: BirthdayResearch/oss-governance-bot@37c8583c6b8596d173b68ffaed543e2485f4f193 # v3.0.0

--- a/.github/workflows/oss-governance-labeler.yml
+++ b/.github/workflows/oss-governance-labeler.yml
@@ -1,4 +1,4 @@
-name: OSS Governance
+name: OSS
 
 on:
   pull_request_target:

--- a/.github/workflows/oss-governance-labels.yml
+++ b/.github/workflows/oss-governance-labels.yml
@@ -1,4 +1,4 @@
-name: OSS Governance
+name: OSS
 
 on:
   push:

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,58 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <HTMLCodeStyleSettings>
+      <option name="HTML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+      <option name="HTML_QUOTE_STYLE" value="Single" />
+      <option name="HTML_ENFORCE_QUOTES" value="true" />
+    </HTMLCodeStyleSettings>
+    <JSCodeStyleSettings version="0">
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="WhenMultiline" />
+      <option name="JSX_ATTRIBUTE_VALUE" value="Based on type" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </JSCodeStyleSettings>
+    <TypeScriptCodeStyleSettings version="0">
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="WhenMultiline" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </TypeScriptCodeStyleSettings>
+    <codeStyleSettings language="GraphQL">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="HTML">
+      <option name="SOFT_MARGINS" value="120" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="SOFT_MARGINS" value="120" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="TypeScript">
+      <option name="SOFT_MARGINS" value="120" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/packages/turbo/cli.js
+++ b/packages/turbo/cli.js
@@ -1,0 +1,3 @@
+#! /usr/bin/env node
+/* eslint-disable */
+require('./dist/cli.js');

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -7,6 +7,9 @@
   "main": "./dist/index.js",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "sticky-turbo": "./cli.js"
+  },
   "files": [
     "dist/**"
   ],
@@ -35,6 +38,9 @@
   },
   "jest": {
     "preset": "@stickyjs/jest"
+  },
+  "dependencies": {
+    "clipanion": "3.2.1"
   },
   "devDependencies": {
     "@stickyjs/jest": "workspace:*",

--- a/packages/turbo/src/TurboPlanCommand.ts
+++ b/packages/turbo/src/TurboPlanCommand.ts
@@ -1,0 +1,30 @@
+import { Command, Option } from 'clipanion';
+import * as process from 'process';
+
+import { Turbo } from './Turbo';
+
+/**
+ * Running `sticky-turbo plan test` generate a list of packages that contains a `test` script in the package.
+ * You can use the output and loop through an array to run test individually via `turbo run test --filter=package`
+ */
+export class TurboPlanCommand extends Command {
+  static override paths = [[`plan`]];
+
+  task = Option.String({ required: true });
+
+  scope = Option.Boolean('--scope', true, {
+    description: 'Include scope in the package name, default to true',
+  });
+
+  async execute(): Promise<void> {
+    const turbo = new Turbo(process.cwd());
+    const packages = turbo.planPackages(this.task).map((name) => {
+      if (this.scope) {
+        return name;
+      }
+      return name.replace(/^@[^/]+\//, '');
+    });
+    this.context.stdout.write(`${JSON.stringify(packages, null, 2)}`);
+    this.context.stdout.write('\n');
+  }
+}

--- a/packages/turbo/src/cli.ts
+++ b/packages/turbo/src/cli.ts
@@ -1,0 +1,6 @@
+import { runExit } from 'clipanion';
+
+import { TurboPlanCommand } from './TurboPlanCommand';
+
+// noinspection JSIgnoredPromiseFromCall
+void runExit([TurboPlanCommand]);

--- a/packages/turbo/turbo.json
+++ b/packages/turbo/turbo.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["//"],
+  "pipeline": {}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,10 @@ importers:
         version: 2.6.11
 
   packages/turbo:
+    dependencies:
+      clipanion:
+        specifier: 3.2.1
+        version: 3.2.1(typanion@3.9.0)
     devDependencies:
       '@stickyjs/jest':
         specifier: workspace:*
@@ -1822,7 +1826,6 @@ packages:
       typanion: '*'
     dependencies:
       typanion: 3.9.0
-    dev: true
 
   /cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -5832,7 +5835,6 @@ packages:
 
   /typanion@3.9.0:
     resolution: {integrity: sha512-7yPk67IIquhKQcUXOBM27vDuGmZf6oJbEmzgVfDniHCkT6+z4JnKY85nKqbstoec8Kp7hD06TP3Kc98ij43PIg==}
-    dev: true
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Introduce new `sticky-turbo plan task` to allow planning of tasks before running them. Built to parallelize CI pipelines for faster PR review intervals.

1. **Test [plan]**: `pnpm sticky-turbo plan test` >> packages.json
2. **Test [$p]**: `for p packages.json`
   1. `pnpm turbo run test --filter=p --concurency=2`
3. **Test [completed]**: for "Branch Protection: Require status checks to pass before merging"
