### PR TITLE
chore(eslint-config): add parseroptions for typescript

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -2,6 +2,10 @@ module.exports = {
   plugins: ['simple-import-sort', 'check-file', 'unused-imports', 'no-only-tests'],
   extends: ['airbnb-base', 'airbnb-typescript/base', 'prettier', 'plugin:anti-trojan-source/recommended'],
   ignorePatterns: ['dist'],
+  parserOptions: {
+    ecmaVersion: 2021,
+    sourceType: 'module',
+  },
   rules: {
     'class-methods-use-this': 'off',
     'max-classes-per-file': 'off',


### PR DESCRIPTION
#### What this PR does / why we need it:

- Not a bug or feature, just suggested when using TypeScript to add parserOptions to the eslint config.
- Can be changed to whatever ecmaVersion you see fit.

#### Which issue(s) will this PR fix?:

> The parserOptions section is typically used in ESLint configuration files for TypeScript projects, where you need to specify the TypeScript parser and relevant language options. TypeScript has its own set of language features and syntax, and ESLint needs to be aware of them in order to correctly analyze and lint TypeScript code.
> 
> In summary, if you are working with JavaScript code, there is no need to include parserOptions in your ESLint configuration. However, if you are working with TypeScript, it is recommended to include parserOptions to configure the TypeScript parser and relevant language options.

#### Additional Comments:

> ecmaVersion - set to 3, 5 (default), 6, 7, 8, 9, 10, 11, 12, 13, 14, or 15 to specify the version of ECMAScript syntax you want to use. You can also set it to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11), 2021 (same as 12), 2022 (same as 13), 2023 (same as 14), or 2024 (same as 15) to use the year-based naming. You can also set "latest" to use the most recently supported version.
>
> sourceType - set to "script" (default) or "module" if your code is in ECMAScript modules.