### PR TITLE
feat(jest): remove `whatwg-fetch` so that we don't pollute global

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -33,7 +33,6 @@
     "jest": "29.6.2",
     "jest-extended": "4.0.1",
     "ts-jest": "29.1.1",
-    "wait-for-expect": "^3.0.2",
-    "whatwg-fetch": "^3.6.17"
+    "wait-for-expect": "^3.0.2"
   }
 }

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -1,3 +1,1 @@
-import 'whatwg-fetch';
-
 export * from './WaitForExpect';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
-      whatwg-fetch:
-        specifier: ^3.6.17
-        version: 3.6.17
 
   packages/prettier:
     dependencies:
@@ -6214,10 +6211,6 @@ packages:
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  /whatwg-fetch@3.6.17:
-    resolution: {integrity: sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ==}
-    dev: false
 
   /whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove `whatwg-fetch` because it `polyfill` and replace any existing fetch implements which creates downstream problem when it had certain expect a certain version of fetch. I recommend any users of `whatwg-fetch` to import it directly instead of rely on `@stickyjs/jest` from providing it.